### PR TITLE
Fix dynamic champion icon version

### DIFF
--- a/application.py
+++ b/application.py
@@ -40,7 +40,7 @@ def get_owned_skins():
 def index():
     version = get_version()
     champions = get_champ_data(version)
-    return render_template('index.html', champions=champions)
+    return render_template('index.html', champions=champions, version=version)
 
 @app.route('/champion/<champion_id>/<champion_key>')
 def champion(champion_id, champion_key):

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
             {% for champion_key, champion_id, champion_name in champions %}
             <li>
                 <a href="{{ url_for('champion', champion_id=champion_id, champion_key=champion_key) }}" target="_self">
-                    <img class="champion-icon" src="https://ddragon.leagueoflegends.com/cdn/11.1.1/img/champion/{{ champion_id }}.png" alt="{{ champion_name }}">
+                    <img class="champion-icon" src="https://ddragon.leagueoflegends.com/cdn/{{ version }}/img/champion/{{ champion_id }}.png" alt="{{ champion_name }}">
                     <div class="champion-name">{{ champion_name[:5] }}</div>
                 </a>
             </li>


### PR DESCRIPTION
## Summary
- ensure index view passes asset version to the template
- load champion icons with the correct version

## Testing
- `python -m py_compile application.py`

------
https://chatgpt.com/codex/tasks/task_e_684d033c01c483228cd9bdd6a8fe868e