### PR TITLE
Fix comment describing link color

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -55,7 +55,7 @@ li {
 
 a {
     text-decoration: none;
-    color: #14c4b5; /* Gold color for links */
+    color: #14c4b5; /* Turquoise color for links */
 }
 
 a:hover {


### PR DESCRIPTION
## Summary
- update comment for link color in CSS to match actual turquoise color

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_684d0c0957f8832292e764e821a68b92